### PR TITLE
fix: wrong en dashes

### DIFF
--- a/WPFPS/Public/Clear-WPFRichTextBox.ps1
+++ b/WPFPS/Public/Clear-WPFRichTextBox.ps1
@@ -30,9 +30,9 @@ function Clear-WPFRichTextBox
 	
 	BEGIN
 	{
-		Add-Type –assemblyName PresentationFramework
-		Add-Type –assemblyName PresentationCore
-		Add-Type –assemblyName WindowsBase
+		Add-Type -assemblyName PresentationFramework
+		Add-Type -assemblyName PresentationCore
+		Add-Type -assemblyName WindowsBase
 	}
 	PROCESS
 	{


### PR DESCRIPTION
En dashes in `Clear-WPFRichTextBox.ps` should be ASCII minus symbol.